### PR TITLE
STCOM-581 update react-router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.4.0 (IN PROGRESS)
 
-* Move react-router to a peerDependency. Refs STCOM-581
+* Move react-router to a peerDependency. Refs STCOM-581.
 
 ## [1.3.0](https://github.com/folio-org/stripes-final-form/tree/v1.3.0) (2019-09-25)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v1.2.0...v1.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-final-form
 
+## 1.3.0 (IN PROGRESS)
+
+* Move react-router to a peerDependency. Refs STCOM-581
+
 ## [1.2.0](https://github.com/folio-org/stripes-final-form/tree/v1.2.0) (2019-09-09)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v1.1.0...v1.2.0)
 

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "prop-types": "^15.5.10",
     "react-final-form": "^6.3.0",
     "react-final-form-arrays": "^3.1.0",
-    "react-intl": "^2.4.0",
-    "react-router": "^4.1.1"
+    "react-intl": "^2.4.0"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "react-router": "^5.0.1"
   }
 }


### PR DESCRIPTION
Update react-router and react-router-dom to v5 and move them from
dependencies to peerDependencies in order to guarantee that all modules
in a platform are on the same version.

Refs [STCOM-581](https://issues.folio.org/browse/STCOM-581)