### PR TITLE
Add initialValues to the subscription prop, refs final-form/final-form#300

### DIFF
--- a/lib/StripesFinalFormWrapper.js
+++ b/lib/StripesFinalFormWrapper.js
@@ -86,6 +86,7 @@ class StripesFinalFormWrapper extends Component {
         {...formOptions}
         subscription={{
           ...subscription,
+          initialValues: true,
           submitting: true,
           pristine: true,
         }}

--- a/lib/StripesFinalFormWrapper.js
+++ b/lib/StripesFinalFormWrapper.js
@@ -85,10 +85,10 @@ class StripesFinalFormWrapper extends Component {
       <FinalForm
         {...formOptions}
         subscription={{
-          ...subscription,
           initialValues: true,
           submitting: true,
           pristine: true,
+          ...subscription,
         }}
         onSubmit={onSubmit}
         decorators={[


### PR DESCRIPTION
- According to https://final-form.org/docs/react-final-form/types/FormRenderProps, any prop provided by the `Form` to the render function or component is dependent upon which values of [formState](https://final-form.org/docs/final-form/types/FormState) we subscribe to. This means, to receive the `initialValues` prop in our render function we would need to subscribe to this value explicitly via the [subscription](https://final-form.org/docs/react-final-form/types/FormProps#subscription) prop. This PR handles this by adding this to `StripesFinalFormWrapper`.

- But to the question as to why was this working before and not in the new release of `RFF` I think the reason is this [PR](https://github.com/final-form/react-final-form/pull/596) which added the feature to `lazyLoad` the `formState`. This PR aims at lazily loading the various props in the `formState` using the [get](https://github.com/final-form/react-final-form/pull/596/files#diff-e7a239e05817ea44782b1803eee0c1deR6) handler here but the `state` variable there somehow _never_ gets the `initialValues` object passed down(this was the cause of breakage) to it and is always undefined. This can be tackled explicitly by adding it to the `subscription` prop which then is available in the state [here](https://github.com/final-form/react-final-form/blob/7d121612d1ad611578a7c60edf54b19ad58e19ae/src/ReactFinalForm.js#L80).

