### PR TITLE
Set propType for Form to be elementType

### DIFF
--- a/lib/StripesFinalFormWrapper.js
+++ b/lib/StripesFinalFormWrapper.js
@@ -149,7 +149,7 @@ class StripesFinalFormWrapper extends Component {
 }
 
 StripesFinalFormWrapper.propTypes = {
-  Form: PropTypes.element,
+  Form: PropTypes.elementType,
   formOptions: PropTypes.shape({
     decorators: PropTypes.array,
     mutators: PropTypes.object,


### PR DESCRIPTION
Removes the console warning ```Warning: Failed prop type: Invalid prop Form of type function supplied to StripesFinalFormWrapper, expected a single ReactElement.```

We are actually passing down a react element type (MyComponent), but not a react element itself (< MyComponent />) for eg: [here](https://github.com/folio-org/ui-agreements/blob/master/src/components/views/AgreementForm.js#L244)