### PR TITLE
STRIPESFF-6 move inter-stripes deps to peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.0.0 (IN PROGRESS)
 
 * Increment `react-router` to `^5.2`. Refs STRIPES-674.
+* Move inter-stripes deps to peers. Refs STRIPESFF-6.
 
 ## [3.0.0](https://github.com/folio-org/stripes-final-form/tree/v3.0.0) (2020-05-20)
 [Full Changelog](https://github.com/folio-org/stripes-final-form/compare/v2.1.0...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.1.0",
+    "@folio/stripes-components": "^8.0.0",
+    "@folio/stripes-core": "^6.0.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^6.2.1",
     "react": "^16.8.6",
@@ -27,8 +29,6 @@
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "@folio/stripes-components": "~8.0.0",
-    "@folio/stripes-core": "~6.0.0",
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.1",
     "final-form-focus": "^1.1.2",
@@ -38,6 +38,8 @@
     "react-final-form-arrays": "^3.1.0"
   },
   "peerDependencies": {
+    "@folio/stripes-components": "^8.0.0",
+    "@folio/stripes-core": "^6.0.0",
     "react": "*",
     "react-intl": "^4.5.3",
     "react-router": "^5.2.0"


### PR DESCRIPTION
Inter-stripes deps should be peers, satisfied as direct-deps only by
`@folio/stripes` itself, to make publishing of minor releases easier
without the risk of introducing multiple copies of a library into the
build.

Refs [STRIPESFF-6](https://issues.folio.org/browse/STRIPESFF-6)