### PR TITLE
STRIPESFF-8 update react-intl to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.1.0 IN PROGRESS
 
+* Increment `react-intl` to `^5.7`. Refs STRIPES-694.
+
 ## [4.0.0](https://github.com/folio-org/stripes-final-form/tree/v4.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-final-form/compare/v3.0.0...v4.0.0)
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@folio/stripes-components": "^8.0.0",
     "@folio/stripes-core": "^6.0.0",
     "react": "*",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.7.0",
     "react-router": "^5.2.0"
   }
 }


### PR DESCRIPTION
Upgrade `react-intl` to `v5.7` as part of the `@folio/stripes` `v5`
update.

Refs [STRIPESFF-8](https://issues.folio.org/browse/STRIPESFF-8)