### PR TITLE
Only setState when mounted

### DIFF
--- a/lib/StripesFinalFormWrapper.js
+++ b/lib/StripesFinalFormWrapper.js
@@ -27,6 +27,8 @@ class StripesFinalFormWrapper extends Component {
       formOptions: { navigationCheck },
     } = this.props;
 
+    this._isMounted = true;
+
     if (navigationCheck) {
       this.unblock = history.block(nextLocation => {
         const {
@@ -49,6 +51,8 @@ class StripesFinalFormWrapper extends Component {
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
+
     if (this.props.formOptions.navigationCheck) {
       this.unblock();
     }
@@ -114,7 +118,11 @@ class StripesFinalFormWrapper extends Component {
                 invalid: true,
                 submitting: true,
               }}
-              onChange={state => this.setState(state)}
+              onChange={state => {
+                if (this._isMounted) {
+                  this.setState(state);
+                }
+              }}
               {...props}
             />
           </>


### PR DESCRIPTION
Prevents `setState` during unmount which is a common issue when running unit tests. Also happens under normal run conditions but not as often AFAIK.

@skomorokh , this is one of the unrelated fixes I mentioned while talking about the react-redux changes.