### PR TITLE
STRIPES-722 Revert "STRIPESFF-10 react v17"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Increment `react-intl` to `^5.7`. Refs STRIPES-694.
 * Increment `stripes-core` to v7.0.0.
 * Increment `stripes-components` to v9.0.0.
-* Increment `react` to v17. Refs STRIPESFF-10.
 
 ## [4.0.0](https://github.com/folio-org/stripes-final-form/tree/v4.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-final-form/compare/v3.0.0...v4.0.0)

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "@folio/stripes-core": "^7.0.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^6.2.1",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "webpack": "^4.10.2"
   },
   "dependencies": {
@@ -38,8 +38,8 @@
     "react-final-form-arrays": "^3.1.0"
   },
   "peerDependencies": {
-    "@folio/stripes-components": "^9.0.0",
-    "@folio/stripes-core": "^7.0.0",
+    "@folio/stripes-components": "^8.0.0",
+    "@folio/stripes-core": "^6.0.0",
     "react": "*",
     "react-intl": "^5.7.0",
     "react-router": "^5.2.0"


### PR DESCRIPTION
Reverts folio-org/stripes-final-form#60

Crackerjack research by @aditya-matukumalli and @mkuklis suggests [onFocus changes in React 17](https://github.com/facebook/react/issues/19743), which have caused [event handling trouble for others](https://eng.wealthfront.com/2021/01/14/upgrading-to-react-17-how-to-fix-the-issues-and-breaking-changes/), may be causing [our woes](https://issues.folio.org/browse/STCOR-504) too. 

Refs [STRIPES-722](https://issues.folio.org/browse/STRIPES-722)