### PR TITLE
use consistent dev/peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "react-final-form-arrays": "^3.1.0"
   },
   "peerDependencies": {
-    "@folio/stripes-components": "^8.0.0",
-    "@folio/stripes-core": "^6.0.0",
+    "@folio/stripes-components": "^9.0.0",
+    "@folio/stripes-core": "^7.0.0",
     "react": "*",
     "react-intl": "^5.7.0",
     "react-router": "^5.2.0"


### PR DESCRIPTION
The `stripes-components` and `stripes-core` dev and peer deps were out
of sync. No longer.