### PR TITLE
point sonarScanDirs at lib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,4 +4,5 @@ buildNPM {
   runLint = 'yes'
   runTest = 'yes'
   runSonarqube = true
+  sonarScanDirs = './lib'
 }


### PR DESCRIPTION
This repository uses `lib`, not the default `src`, so we need to tell
Jenkins that so our PRs will stop dying in CI.