### PR TITLE
STRIPESFF-15 Migrate to `@babel/eslint-parser`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,4 @@
 {
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "extends": "@folio/eslint-config-stripes"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 6.1.0 IN PROGRESS
 
-* Upgrade NodeJS to active LTS, v16. Refs STFRIPESFF-16.
+* Upgrade NodeJS to active LTS, v16. Refs STRIPESFF-16.
+* Migrate to `@babel/eslint-parser`. Refs STRIPESFF-15.
 
 ## [6.0.0](https://github.com/folio-org/stripes-final-form/tree/v6.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-final-form/compare/v5.1.0...v6.0.0)

--- a/lib/StripesFinalFormWrapper.js
+++ b/lib/StripesFinalFormWrapper.js
@@ -159,7 +159,7 @@ class StripesFinalFormWrapper extends Component {
 StripesFinalFormWrapper.propTypes = {
   Form: PropTypes.elementType,
   formOptions: PropTypes.shape({
-    decorators: PropTypes.array,
+    decorators: PropTypes.arrayOf(PropTypes.object),
     mutators: PropTypes.object,
     navigationCheck: PropTypes.bool,
     subscription: PropTypes.object

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "node": ">=14.0.0"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^5.1.0",
+    "@babel/core": "^7.18.2",
+    "@babel/eslint-parser": "^7.18.2",
+    "@folio/eslint-config-stripes": "^6.1.0",
     "@folio/stripes-components": "^10.0.0",
     "@folio/stripes-core": "^8.0.0",
-    "babel-eslint": "^9.0.0",
-    "eslint": "^6.2.1",
+    "eslint": "^7.32.0",
+    "eslint-import-resolver-webpack": "^0.13.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "webpack": "^4.10.2"


### PR DESCRIPTION
Replace `babel-eslint` with `@babel/eslint-parser` so we can stay
current with eslint.

Refs [STRIPESFF-15](https://issues.folio.org/browse/STRIPESFF-15)