### PR TITLE
STRIPESFF-19: The 'are you sure' modal window is not offered after re-editing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-final-form
 
+## (IN PROGRESS)
+
+* The "are you sure" modal window is not offered after re-editing. Refs STRIPESFF-19
+
 ## [6.1.0](https://github.com/folio-org/stripes-final-form/tree/v6.1.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-final-form/compare/v6.0.0...v6.1.0)
 

--- a/lib/StripesFinalFormWrapper.js
+++ b/lib/StripesFinalFormWrapper.js
@@ -120,7 +120,13 @@ class StripesFinalFormWrapper extends Component {
               }}
               onChange={state => {
                 if (this._isMounted) {
-                  this.setState(state);
+                  const { dirty, submitSucceeded } = state;
+                  if (dirty && submitSucceeded) {
+                    const newState = { ...state, submitSucceeded : false };
+                    this.setState(newState);
+                  } else {
+                    this.setState(state);
+                  }
                 }
               }}
               {...props}


### PR DESCRIPTION
## Purpose
The 'are you sure' modal window is not offered after re-editing.
## Issue
[STRIPESFF-19](https://issues.folio.org/browse/STRIPESFF-19)
## Approach
The "are you sure" modal window is not offered after re-editing.
Stripes-final-form wrapper offers invocation of confirmation modal when user navigates to some other page while there are unsaved changes. On re-editing the form, i.e., save the changes and edit the form one more time, the confirmation modal is not invoked and navigation happens. The root cause for this behavior is "submitSucceded" state being set to true on initial save success. Hence, onChange handler(FormSpy) can be tweaked while setting the the state of the wrapper component. This change is implemented in this PR.
I see that this behavior can be mimicked at component level too, but it will never use the confirmation modal in this wrapper and leads to redundant code.

