### PR TITLE
Revert "STRIPESFF-19: The 'are you sure' modal window is not offered after re-editing."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change history for stripes-final-form
 
-## (IN PROGRESS)
-
-* The "are you sure" modal window is not offered after re-editing. Refs STRIPESFF-19
-
 ## [6.1.0](https://github.com/folio-org/stripes-final-form/tree/v6.1.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-final-form/compare/v6.0.0...v6.1.0)
 

--- a/lib/StripesFinalFormWrapper.js
+++ b/lib/StripesFinalFormWrapper.js
@@ -120,13 +120,7 @@ class StripesFinalFormWrapper extends Component {
               }}
               onChange={state => {
                 if (this._isMounted) {
-                  const { dirty, submitSucceeded } = state;
-                  if (dirty && submitSucceeded) {
-                    const newState = { ...state, submitSucceeded : false };
-                    this.setState(newState);
-                  } else {
-                    this.setState(state);
-                  }
+                  this.setState(state);
                 }
               }}
               {...props}


### PR DESCRIPTION
Reverts folio-org/stripes-final-form#81

This change causes a test failure within `stripes-smart-components` CustomFields. We need to investigate this issue and possibly make adjustments to this change, the consuming code in `stripes-smart-components`, or both.