### PR TITLE
bump major version to 7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-final-form",
-  "version": "6.1.1",
+  "version": "7.0.0",
   "description": "Form state management in Stripes based on Final Form.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-final-form",
@@ -22,8 +22,8 @@
     "@babel/core": "^7.18.2",
     "@babel/eslint-parser": "^7.18.2",
     "@folio/eslint-config-stripes": "^6.1.0",
-    "@folio/stripes-components": "^10.0.0",
-    "@folio/stripes-core": "^8.0.0",
+    "@folio/stripes-components": "^11.0.0",
+    "@folio/stripes-core": "^9.0.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-webpack": "^0.13.2",
     "react": "^17.0.2",
@@ -40,8 +40,8 @@
     "react-final-form-arrays": "^3.1.0"
   },
   "peerDependencies": {
-    "@folio/stripes-components": "^10.0.0",
-    "@folio/stripes-core": "^8.0.0",
+    "@folio/stripes-components": "^11.0.0",
+    "@folio/stripes-core": "^9.0.0",
     "react": "^17.0.2",
     "react-intl": "^5.7.0",
     "react-router": "^5.2.0"


### PR DESCRIPTION
Bump the major version to accommodate breaking changes in the peer-dependencies stripes-core and stripes-components.