### PR TITLE
STRIPESFF-21 bump flat to avoid security concerns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-final-form
 
+## 7.0.0 IN PROGRESS
+
+* Bump `flat` to avoid security concerns. Refs STRIPESFF-21.
+
 ## [6.1.1](https://github.com/folio-org/stripes-final-form/tree/v6.1.1) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-final-form/compare/v6.1.0...v6.1.1)
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.1",
     "final-form-focus": "^1.1.2",
-    "flat": "^4.0.0",
+    "flat": "^5.0.2",
     "prop-types": "^15.5.10",
     "react-final-form": "^6.3.0",
     "react-final-form-arrays": "^3.1.0"


### PR DESCRIPTION
Bump `flat` to v5 to avoid prototype pollution in v4.

Refs [STRIPESFF-21](https://issues.folio.org/browse/STRIPESFF-21)