### PR TITLE
STRIPESFF-30 BREAKING bump react to v18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Avoid private paths in stripes-core imports. Refs STRIPESFF-27.
 * Compile translations. Refs STRIPESFF-29.
+* *BREAKING* Upgrade `react` to `v18`. Refs STRIPESFF-30.
 
 ## [7.0.0](https://github.com/folio-org/stripes-final-form/tree/v7.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-final-form/compare/v6.1.1...v7.0.0)

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   "devDependencies": {
     "@babel/core": "^7.18.2",
     "@babel/eslint-parser": "^7.18.2",
-    "@folio/eslint-config-stripes": "^6.1.0",
-    "@folio/stripes-components": "^11.0.0",
-    "@folio/stripes-core": "^9.0.0",
+    "@folio/eslint-config-stripes": "^7.0.0",
+    "@folio/stripes-components": "^12.0.0",
+    "@folio/stripes-core": "^10.0.0",
     "@formatjs/cli": "^6.0.4",
     "eslint": "^7.32.0",
     "eslint-import-resolver-webpack": "^0.13.2",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "webpack": "^4.10.2"
   },
   "dependencies": {
@@ -42,9 +42,9 @@
     "react-final-form-arrays": "^3.1.0"
   },
   "peerDependencies": {
-    "@folio/stripes-components": "^11.0.0",
-    "@folio/stripes-core": "^9.0.0",
-    "react": "^17.0.2",
+    "@folio/stripes-components": "^12.0.0",
+    "@folio/stripes-core": "^10.0.0",
+    "react": "^18.2.0",
     "react-intl": "^5.7.0",
     "react-router": "^5.2.0"
   }


### PR DESCRIPTION
Update `react` to `v18`

Refs [STRIPESFF-30](https://issues.folio.org/browse/STRIPESFF-30)