### PR TITLE
STRIPESFF-35 always permit navigation to /logout locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 8.1.0 IN PROGRESS
 
+* Ignore the dirty-form prompt when navigating to a logout location. STRIPESFF-35.
+
+## [8.0.1](https://github.com/folio-org/stripes-final-form/tree/v8.0.1) (2024-03-13)
+[Full Changelog](https://github.com/folio-org/stripes-final-form/compare/v8.0.0...v8.0.1)
+
+* Update translations
+
 ## [8.0.0](https://github.com/folio-org/stripes-final-form/tree/v8.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-final-form/compare/v7.0.0...v8.0.0)
 

--- a/lib/StripesFinalFormWrapper.js
+++ b/lib/StripesFinalFormWrapper.js
@@ -31,6 +31,13 @@ class StripesFinalFormWrapper extends Component {
 
     if (navigationCheck) {
       this.unblock = history.block(nextLocation => {
+        // STRIPESFF-35 / STFORM-42 require the nav-prompt to be ignored
+        // on logout. consider calling a common function if this ever needs
+        // to be more elaborate; until then, admire this dead-simple impl.
+        if (nextLocation.pathname.startsWith('/logout')) {
+          return true;
+        }
+
         const {
           dirty,
           submitSucceeded,


### PR DESCRIPTION
Always permit navigation to a `/logout` location, even if it would normally be prevented due to a dirty form.

Refs [STRIPESFF-35](https://folio-org.atlassian.net/browse/STRIPESFF-35)