### PR TITLE
STRIPESFF-38 GA: omit publishing MD

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -6,9 +6,13 @@ on:
 
 jobs:
   ui:
-    uses: folio-org/.github/.github/workflows/ui.yml@v1.1
+    uses: folio-org/.github/.github/workflows/ui.yml@v1.5
+    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit
     with:
       jest-enabled: true
       jest-test-command: yarn run test
       sonar-sources: ./lib
+      generate-module-descriptor: false
+      publish-module-descriptor: false
+


### PR DESCRIPTION
There is no module descriptor here. Additionally, make this workflow conditional to avoid running twice when GA logs multiple events for the same action when opening a new PR.

Refs [STRIPESFF-38](https://folio-org.atlassian.net/browse/STRIPESFF-38), [STRIPES-938](https://folio-org.atlassian.net/browse/STRIPES-938)