### PR TITLE
STRIPESFF-39: ECS - display Cancel confirmation popup on users edit page with not uniq username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 8.2.0 IN PROGRESS
 
+* ESC - Cancel confirmation popup does not appear on user edit page after entering not unique Username. Refs STRIPESFF-39.
+
 ## [8.1.0](https://github.com/folio-org/stripes-final-form/tree/v8.1.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-final-form/compare/v8.0.1...v8.1.0)
 

--- a/lib/StripesFinalFormWrapper.js
+++ b/lib/StripesFinalFormWrapper.js
@@ -121,7 +121,7 @@ class StripesFinalFormWrapper extends Component {
             <FormSpy
               subscription={{
                 dirty: true,
-                submitSucceeded: true,
+                submitSucceeded: false,
                 invalid: true,
                 submitting: true,
               }}


### PR DESCRIPTION
### Purpose
The issue arises when a user tries to edit their `username` but enters a non-unique (already taken) username, then clicks the Cancel button. In this scenario, the Cancel confirmation dialog does not appear as expected.

The reason for this behavior is that `submitSucceeded` [property here](https://github.com/folio-org/stripes-final-form/blob/master/lib/StripesFinalFormWrapper.js#L124) is initially set to `true`, which means the form mistakenly assumes that the submission was successful, even though it wasn’t due to the username conflict. This causes the form to skip the Cancel confirmation prompt.

### Approach

https://github.com/user-attachments/assets/17eddb43-2147-43f4-8773-d2f5d64fc72b

