### PR TITLE
STRIPESFF-49 handle nav guard via stripes-core::isGuardable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Supply Personal Data Disclosure form. Refs STRIPESFF-47.
+* Handle unguardable navigation via stripes-core::isGuardable. Refs STRIPESFF-49.
 
 ## 9.0.0 IN PROGRESS
 

--- a/lib/StripesFinalFormWrapper.js
+++ b/lib/StripesFinalFormWrapper.js
@@ -5,7 +5,7 @@ import { Form as FinalForm, FormSpy } from 'react-final-form';
 import createDecorator from 'final-form-focus';
 import arrayMutators from 'final-form-arrays';
 import { FormattedMessage } from 'react-intl';
-import { LastVisitedContext } from '@folio/stripes-core';
+import { LastVisitedContext, isGuardable } from '@folio/stripes-core';
 import { ConfirmationModal } from '@folio/stripes-components';
 
 const focusOnErrors = createDecorator();
@@ -31,10 +31,8 @@ class StripesFinalFormWrapper extends Component {
 
     if (navigationCheck) {
       this.unblock = history.block(nextLocation => {
-        // STRIPESFF-35 / STFORM-42 require the nav-prompt to be ignored
-        // on logout. consider calling a common function if this ever needs
-        // to be more elaborate; until then, admire this dead-simple impl.
-        if (nextLocation.pathname.startsWith('/logout')) {
+        // some nav (e.g. to `/logout` when a session ends) cannot be guarded
+        if (!isGuardable(nextLocation.pathName)) {
           return true;
         }
 


### PR DESCRIPTION
Instead of hard-coding `/logout` as unguardable-navigation, leverage stripes-core's `isGuardable()`.

Refs [STRIPESFF-49](https://folio-org.atlassian.net/browse/STRIPESFF-49), [STRIPES-1026](https://folio-org.atlassian.net/browse/STRIPES-1026)