### PR TITLE
STRIPESFF-50 pass correct arguments to stripes-core::isGuardable

### DIFF
--- a/lib/StripesFinalFormWrapper.js
+++ b/lib/StripesFinalFormWrapper.js
@@ -32,7 +32,7 @@ class StripesFinalFormWrapper extends Component {
     if (navigationCheck) {
       this.unblock = history.block(nextLocation => {
         // some nav (e.g. to `/logout` when a session ends) cannot be guarded
-        if (!isGuardable(nextLocation.pathName)) {
+        if (!isGuardable(nextLocation.pathname)) {
           return true;
         }
 


### PR DESCRIPTION
Pass `nextLocation.pathname`. `nextLocation.pathName` is not a thing. Whoops.

Refs [STRIPESFF-50](https://folio-org.atlassian.net/browse/STRIPESFF-50), [STRIPESFF-49](https://folio-org.atlassian.net/browse/STRIPESFF-49)